### PR TITLE
[FE] 카테고리 페이지 [ISSUE-52]

### DIFF
--- a/src/main/kotlin/me/youngjun/daangnmarket/api/category/controller/CategoryApiController.kt
+++ b/src/main/kotlin/me/youngjun/daangnmarket/api/category/controller/CategoryApiController.kt
@@ -3,15 +3,23 @@ package me.youngjun.daangnmarket.api.category.controller
 import me.youngjun.daangnmarket.api.category.service.CategoryService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class CategoryApiController(
-    private val categoryService: CategoryService
+    private val categoryService: CategoryService,
 ) {
     @GetMapping("/api/v1/category/list")
     fun getCategoryListView(): ResponseEntity<Any> {
         val categoryList = categoryService.getCategoryList()
         return ResponseEntity.ok(categoryList)
+    }
+
+    @GetMapping("/api/v1/category/name")
+    fun getCategoryName(
+        @RequestParam("category_code") categoryCode: String,
+    ): ResponseEntity<String> {
+        return ResponseEntity.ok(categoryService.getCategory(categoryCode).name)
     }
 }

--- a/src/main/kotlin/me/youngjun/daangnmarket/api/category/dto/CategoryView.kt
+++ b/src/main/kotlin/me/youngjun/daangnmarket/api/category/dto/CategoryView.kt
@@ -2,5 +2,5 @@ package me.youngjun.daangnmarket.api.category.dto
 
 data class CategoryView(
     val categoryCode: String,
-    val categoryName: String
+    val categoryName: String,
 )

--- a/src/main/kotlin/me/youngjun/daangnmarket/api/category/service/CategoryService.kt
+++ b/src/main/kotlin/me/youngjun/daangnmarket/api/category/service/CategoryService.kt
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service
 
 @Service
 class CategoryService(
-    private val categoryRepository: CategoryRepository
+    private val categoryRepository: CategoryRepository,
 ) {
     fun getCategoryList(): List<CategoryView> {
         val categoryViewList = mutableListOf<CategoryView>()
@@ -21,9 +21,7 @@ class CategoryService(
         return categoryViewList
     }
 
-    fun getCategory(
-        categoryId: Long
-    ): Category {
+    fun getCategory(categoryId: Long): Category {
         return categoryRepository.findByIdOrNull(categoryId)
             ?: throw NotFoundException(ErrorCode.CATEGORY_NOT_FOUND)
     }

--- a/src/main/kotlin/me/youngjun/daangnmarket/api/category/service/CategoryService.kt
+++ b/src/main/kotlin/me/youngjun/daangnmarket/api/category/service/CategoryService.kt
@@ -6,7 +6,6 @@ import me.youngjun.daangnmarket.common.domain.enum.CategoryEnum
 import me.youngjun.daangnmarket.common.repository.CategoryRepository
 import me.youngjun.daangnmarket.infra.exception.ErrorCode
 import me.youngjun.daangnmarket.infra.exception.NotFoundException
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 
 @Service
@@ -21,8 +20,8 @@ class CategoryService(
         return categoryViewList
     }
 
-    fun getCategory(categoryId: Long): Category {
-        return categoryRepository.findByIdOrNull(categoryId)
+    fun getCategory(categoryCode: String): Category {
+        return categoryRepository.findByCode(categoryCode)
             ?: throw NotFoundException(ErrorCode.CATEGORY_NOT_FOUND)
     }
 }

--- a/src/main/kotlin/me/youngjun/daangnmarket/api/product/controller/ProductApiController.kt
+++ b/src/main/kotlin/me/youngjun/daangnmarket/api/product/controller/ProductApiController.kt
@@ -35,7 +35,7 @@ class ProductApiController(
     @GetMapping("/api/v1/product/list")
     fun getProductList(
         principal: Principal,
-        @RequestParam("category_id") categoryId: Long?,
+        @RequestParam("category_code") categoryCode: String?,
         @RequestParam("status") status: ProductStatus?,
         @RequestParam("likes") likes: Boolean?,
         @RequestParam("member_id") memberId: Long?,
@@ -44,7 +44,7 @@ class ProductApiController(
         @RequestParam("size") size: Int?,
     ): ResponseEntity<Page<ProductView>> {
         val filter = ProductFilterDto(
-            categoryId,
+            categoryCode,
             status,
             likes,
             memberId,

--- a/src/main/kotlin/me/youngjun/daangnmarket/api/product/dto/ProductFilterDto.kt
+++ b/src/main/kotlin/me/youngjun/daangnmarket/api/product/dto/ProductFilterDto.kt
@@ -3,9 +3,9 @@ package me.youngjun.daangnmarket.api.product.dto
 import me.youngjun.daangnmarket.common.domain.ProductStatus
 
 data class ProductFilterDto(
-    val categoryId: Long?,
+    val categoryCode: String?,
     val status: ProductStatus?,
     val likes: Boolean?,
     val memberId: Long?,
-    val searchKeyWord: String?
+    val searchKeyWord: String?,
 )

--- a/src/main/kotlin/me/youngjun/daangnmarket/api/product/dto/ProductRegisterDto.kt
+++ b/src/main/kotlin/me/youngjun/daangnmarket/api/product/dto/ProductRegisterDto.kt
@@ -4,10 +4,10 @@ data class ProductRegisterDto(
     // @NotBlank(message = "제목을 입력해주세요")
     val title: String,
     val areaId: Long,
-    val categoryId: Long,
+    val categoryCode: String,
     // @NotBlank(message = "가격을 입력해주세요")
     val price: Long,
     // @NotBlank(message = "게시글 내용을 입력해주세요")
     val content: String,
-    val imageList: List<String>
+    val imageList: List<String>,
 )

--- a/src/main/kotlin/me/youngjun/daangnmarket/api/product/dto/ProductUpdateDto.kt
+++ b/src/main/kotlin/me/youngjun/daangnmarket/api/product/dto/ProductUpdateDto.kt
@@ -5,9 +5,9 @@ import me.youngjun.daangnmarket.common.domain.ProductStatus
 data class ProductUpdateDto(
     val id: Long,
     val title: String,
-    val categoryId: Long,
+    val categoryCode: String,
     val price: Long,
     val content: String,
     val imageList: List<String>,
-    val status: ProductStatus? = ProductStatus.TRADING
+    val status: ProductStatus? = ProductStatus.TRADING,
 )

--- a/src/main/kotlin/me/youngjun/daangnmarket/api/product/service/ProductService.kt
+++ b/src/main/kotlin/me/youngjun/daangnmarket/api/product/service/ProductService.kt
@@ -47,7 +47,7 @@ class ProductService(
             ?: throw NotFoundMemberException(ErrorCode.DEFAULT_NOT_FOUND)
         val area = areaRepository.findByIdOrNull(registerDto.areaId)
             ?: throw NotFoundAreaException(ErrorCode.AREA_NOT_FOUND)
-        val category = categoryService.getCategory(registerDto.categoryId)
+        val category = categoryService.getCategory(registerDto.categoryCode)
         val productEntity = Product.convertToEntity(registerDto, member)
         productEntity.areaId = area
         productEntity.categoryId = category
@@ -81,8 +81,8 @@ class ProductService(
             area = tempMember.areaId
         }
 
-        val category = if (filter.categoryId != null) {
-            categoryService.getCategory(filter.categoryId)
+        val category = if (filter.categoryCode != null) {
+            categoryService.getCategory(filter.categoryCode)
         } else {
             null
         }
@@ -148,7 +148,7 @@ class ProductService(
             productId = product.id!!,
             imageList = imageList,
         )
-        val category = categoryService.getCategory(updateDto.categoryId)
+        val category = categoryService.getCategory(updateDto.categoryCode)
 
         product.title = updateDto.title
         product.categoryId = category

--- a/src/main/kotlin/me/youngjun/daangnmarket/common/domain/enum/CategoryEnum.kt
+++ b/src/main/kotlin/me/youngjun/daangnmarket/common/domain/enum/CategoryEnum.kt
@@ -2,7 +2,7 @@ package me.youngjun.daangnmarket.common.domain.enum
 
 enum class CategoryEnum(
     val code: String,
-    val detail: String
+    val detail: String,
 ) {
     DIGITAL_DEVICE("0", "디지털기기"),
     HOME_APPLIANCES("1", "생활가전"),
@@ -20,11 +20,12 @@ enum class CategoryEnum(
     BOOK_TICKET_ALBUM("13", "도서/티켓/음반"),
     PLANT("14", "식물"),
     OTHER_USED_GOODS("15", "기타 중고물품"),
-    USED_CAR("16", "중고차");
+    USED_CAR("16", "중고차"),
+    ;
 
     companion object {
         fun of(
-            code: String
+            code: String,
         ): CategoryEnum? = CategoryEnum.values().firstOrNull() {
             it.code == code
         }

--- a/src/main/kotlin/me/youngjun/daangnmarket/common/repository/CategoryRepository.kt
+++ b/src/main/kotlin/me/youngjun/daangnmarket/common/repository/CategoryRepository.kt
@@ -4,5 +4,5 @@ import me.youngjun.daangnmarket.common.domain.Category
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface CategoryRepository : JpaRepository<Category, Long> {
-    fun findByCode(code: String): Category
+    fun findByCode(code: String): Category?
 }

--- a/vue/src/router/index.js
+++ b/vue/src/router/index.js
@@ -8,6 +8,7 @@ import ProductListView from "@/views/product/ProductListView.vue";
 import ProductRegisterView from "@/views/product/ProductRegisterView.vue";
 import ProductDetailView from "@/views/product/ProductDetailView.vue";
 import MyPageView from "@/views/member/MyPageView.vue";
+import CategoryView from "@/views/product/CategoryView.vue";
 
 const router = createRouter({
     history: createWebHistory(),
@@ -51,7 +52,12 @@ const router = createRouter({
             path: "/my-page",
             name: "MyPageView",
             component: MyPageView,
-        }
+        },
+        {
+            path: "/category-list",
+            name: "CategoryView",
+            component: CategoryView,
+        },
     ],
 });
 

--- a/vue/src/router/index.js
+++ b/vue/src/router/index.js
@@ -34,7 +34,7 @@ const router = createRouter({
             component: JoinOkView,
         },
         {
-            path: "/product/list",
+            path: "/product/list/:category_code?",
             name: "ProductList",
             component: ProductListView,
         },

--- a/vue/src/views/product/CategoryView.vue
+++ b/vue/src/views/product/CategoryView.vue
@@ -12,12 +12,12 @@
         :key="index"
         @click="goProductHomeByCategory(item.categoryCode)">
       <v-card class="category-card">
-        <v-icon v-if="item?.categoryCode === '0'" icon="mdi-camera-gopro"></v-icon><!---->
+        <v-icon v-if="item?.categoryCode === '0'" icon="mdi-camera-gopro"></v-icon>
         <v-icon v-else-if="item?.categoryCode === '1'" icon="mdi-television-classic"></v-icon>
-        <v-icon v-else-if="item?.categoryCode === '2'" icon="mdi-home-variant"></v-icon> <!---->
+        <v-icon v-else-if="item?.categoryCode === '2'" icon="mdi-home-variant"></v-icon>
         <v-icon v-else-if="item?.categoryCode === '3'" icon="mdi-baby-buggy"></v-icon>
         <v-icon v-else-if="item?.categoryCode === '4'" icon="mdi-food-fork-drink"></v-icon>
-        <v-icon v-else-if="item?.categoryCode === '5'" icon="mdi-book"></v-icon><!---->
+        <v-icon v-else-if="item?.categoryCode === '5'" icon="mdi-book"></v-icon>
         <v-icon v-else-if="item?.categoryCode === '6'" icon="mdi-bike"></v-icon>
         <v-icon v-else-if="item?.categoryCode === '7'" icon="mdi-ring"></v-icon>
         <v-icon v-else-if="item?.categoryCode === '8'" icon="mdi-tshirt-crew"></v-icon>
@@ -67,9 +67,10 @@ export default {
             alert("서버 에러입니다. \n잠시 후 다시 시도해주세요.");
           });
     };
-    const goProductHomeByCategory = () => {
+    const goProductHomeByCategory = (categoryCode) => {
       router.push({
-        name: "HomeView"
+        name: "ProductList",
+        params: {category_code: categoryCode}
       })
     };
     return {

--- a/vue/src/views/product/CategoryView.vue
+++ b/vue/src/views/product/CategoryView.vue
@@ -1,0 +1,90 @@
+<template>
+  <v-toolbar color="orange" elevation="2" opacity="100">
+    <!--TODO("뒤로가기 기능")-->
+    <v-icon icon="mdi-arrow-left" style="margin-left: 10px;"></v-icon>
+    <v-toolbar-title class="text-left">카테고리</v-toolbar-title>
+  </v-toolbar>
+  <v-container fluid>
+    <v-row
+        class="mb-4"
+        style="display: inline;"
+        v-for="(item, index) in state.categoryList"
+        :key="index"
+        @click="goProductHomeByCategory(item.categoryCode)">
+      <v-card class="category-card">
+        <v-icon v-if="item?.categoryCode === '0'" icon="mdi-camera-gopro"></v-icon><!---->
+        <v-icon v-else-if="item?.categoryCode === '1'" icon="mdi-television-classic"></v-icon>
+        <v-icon v-else-if="item?.categoryCode === '2'" icon="mdi-home-variant"></v-icon> <!---->
+        <v-icon v-else-if="item?.categoryCode === '3'" icon="mdi-baby-buggy"></v-icon>
+        <v-icon v-else-if="item?.categoryCode === '4'" icon="mdi-food-fork-drink"></v-icon>
+        <v-icon v-else-if="item?.categoryCode === '5'" icon="mdi-book"></v-icon><!---->
+        <v-icon v-else-if="item?.categoryCode === '6'" icon="mdi-bike"></v-icon>
+        <v-icon v-else-if="item?.categoryCode === '7'" icon="mdi-ring"></v-icon>
+        <v-icon v-else-if="item?.categoryCode === '8'" icon="mdi-tshirt-crew"></v-icon>
+        <v-icon v-else-if="item?.categoryCode === '9'" icon="mdi-tie"></v-icon>
+        <v-icon v-else-if="item?.categoryCode === '10'" icon="mdi-gamepad-variant"></v-icon>
+        <v-icon v-else-if="item?.categoryCode === '11'" icon="mdi-broom"></v-icon>
+        <v-icon v-else-if="item?.categoryCode === '12'" icon="mdi-cat"></v-icon>
+        <v-icon v-else-if="item?.categoryCode === '13'" icon="mdi-book-open-page-variant"></v-icon>
+        <v-icon v-else-if="item?.categoryCode === '14'" icon="mdi-flower"></v-icon>
+        <v-icon v-else-if="item?.categoryCode === '15'" icon="mdi-recycle"></v-icon>
+        <v-icon v-else-if="item?.categoryCode === '16'" icon="mdi-car-hatchback"></v-icon>
+        <br>
+        {{ item?.categoryName }}
+      </v-card>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+import {onMounted, reactive} from "vue";
+import $axiosInst from "@/common/AxiosInst"
+import router from "@/router";
+
+export default {
+  setup() {
+    const state = reactive({
+      categoryList: [
+        {
+          categoryCode: "",
+          categoryName: "",
+        }
+      ],
+    });
+    onMounted(() => {
+      getCategoryList();
+    });
+    const getCategoryList = () => {
+      const url = "/api/v1/category/list";
+      $axiosInst
+          .get(url)
+          .then(function (response) {
+            console.log(response);
+            state.categoryList = response.data;
+          })
+          .catch(function (error) {
+            console.log(error);
+            alert("서버 에러입니다. \n잠시 후 다시 시도해주세요.");
+          });
+    };
+    const goProductHomeByCategory = () => {
+      router.push({
+        name: "HomeView"
+      })
+    };
+    return {
+      state,
+      goProductHomeByCategory,
+    };
+  }
+};
+</script>
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style scoped>
+.category-card {
+  display: inline-block;
+  width: 30%;
+  margin: 17px 17px;
+}
+</style>

--- a/vue/src/views/product/ProductListView.vue
+++ b/vue/src/views/product/ProductListView.vue
@@ -62,9 +62,12 @@ import heartImg from "@/assets/img/heart.png";
 import addButton from "@/assets/img/add-button.png";
 import reservedImg from "@/assets/img/reserved.png";
 import completedImg from "@/assets/img/completed.png";
+import {useRoute} from "vue-router";
 
 export default {
   setup() {
+    const route = useRoute();
+    const categoryCode = route.params.category_code;
     const state = reactive({
       list: [
         {
@@ -84,7 +87,7 @@ export default {
       addButton: addButton,
       reservedImg: reservedImg,
       completedImg: completedImg,
-      userName: ""
+      userName: "",
     });
     onMounted(() => {
       getProductList();
@@ -92,8 +95,12 @@ export default {
     });
     const getProductList = () => {
       const url = "/api/v1/product/list";
+      let params;
+      if (categoryCode !== "") {
+        params = {category_code: categoryCode}
+      }
       $axiosInst
-          .get(url)
+          .get(url, {params})
           .then(function (response) {
             console.log(response);
             state.list = response.data.content;
@@ -114,6 +121,7 @@ export default {
       })
     };
     return {
+      categoryCode,
       state,
       goDetailPage,
     };

--- a/vue/src/views/product/ProductListView.vue
+++ b/vue/src/views/product/ProductListView.vue
@@ -5,7 +5,9 @@
     <!--TODO("검색 페이지 연결")-->
     <!--TODO("카테고리 조회 페이지 연결")-->
     <v-icon icon="mdi-magnify"></v-icon>&nbsp; &nbsp;
-    <v-icon icon="mdi-format-list-bulleted"></v-icon>&nbsp; &nbsp;
+    <v-btn icon id="no-background-hover" to="/category-list">
+      <v-icon icon="mdi-format-list-bulleted"></v-icon>&nbsp; &nbsp;
+    </v-btn>
   </v-toolbar>
   <v-container fluid>
     <v-row
@@ -159,5 +161,9 @@ export default {
 .like-img {
   vertical-align: middle;
   margin-right: -3px;
+}
+
+#no-background-hover::before {
+  background-color: transparent !important;
 }
 </style>

--- a/vue/src/views/product/ProductListView.vue
+++ b/vue/src/views/product/ProductListView.vue
@@ -1,9 +1,12 @@
 <template>
   <v-toolbar color="orange" elevation="2">
-    <v-toolbar-title>{{ state?.userName }}님 동네</v-toolbar-title>
-    <v-spacer></v-spacer>
+    <v-icon v-if="categoryCode !== ''" icon="mdi-arrow-left" style="margin-left: 10px; margin-right: 40px"></v-icon>
+    <v-toolbar-title v-if="categoryCode === ''">{{ state?.userName }}님 동네</v-toolbar-title>
+    <v-toolbar-title v-else>
+      {{ state.categoryName }}
+    </v-toolbar-title>
+    <v-spacer v-if="categoryCode === ''"></v-spacer>
     <!--TODO("검색 페이지 연결")-->
-    <!--TODO("카테고리 조회 페이지 연결")-->
     <v-icon icon="mdi-magnify"></v-icon>&nbsp; &nbsp;
     <v-btn icon id="no-background-hover" to="/category-list">
       <v-icon icon="mdi-format-list-bulleted"></v-icon>&nbsp; &nbsp;
@@ -88,10 +91,12 @@ export default {
       reservedImg: reservedImg,
       completedImg: completedImg,
       userName: "",
+      categoryName: "",
     });
     onMounted(() => {
       getProductList();
       setUserName();
+      setCategoryName();
     });
     const getProductList = () => {
       const url = "/api/v1/product/list";
@@ -120,10 +125,28 @@ export default {
         params: {productId: id}
       })
     };
+    const setCategoryName = () => {
+      const url = "/api/v1/category/name";
+      let params;
+      if (categoryCode !== "") {
+        params = {category_code: categoryCode}
+        $axiosInst
+            .get(url, {params})
+            .then(function (response) {
+              console.log(response);
+              state.categoryName = response.data;
+            })
+            .catch(function (error) {
+              console.log(error);
+              alert("서버 에러입니다. \n잠시 후 다시 시도해주세요.");
+            });
+      }
+    };
     return {
       categoryCode,
       state,
       goDetailPage,
+      setCategoryName,
     };
   }
 };


### PR DESCRIPTION
## ✨ Summary

1. 메인 홈 → 카테고리 조회 페이지를 구성합니다.
2. 카테고리 선택 → 상품 Home (카테고리 필터 적용) 라우팅

<img width="250" alt="img" src="https://user-images.githubusercontent.com/42997924/222563919-589a1b08-bda1-4154-8f5d-73b9b1226a3f.png">

## ✍🏻 Describe changes

- 카테고리 별 이미지 추가
- 카테고리 조회 API 호출
- 카테고리 선택 시 상품 리스트 조회 페이지 landing
- 카테고리 필터 적용 시 상품 home 제목 변경

<img width="250" alt="gif" src="https://user-images.githubusercontent.com/42997924/222969084-6798b919-9d3c-4e94-8043-f7b1665ccb42.gif">

## 📌 Issue number

resolved: #52