### PR TITLE
[FE] 나의 판매내역 페이지 개발 [ISSUE-45]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
 
     // querydsl 관련 의존성
     implementation("com.querydsl:querydsl-jpa:5.0.0")
+    testImplementation("io.kotest:kotest-runner-junit5-jvm:4.6.0")
     kapt("com.querydsl:querydsl-apt:5.0.0:jpa")
 
     // mysql

--- a/src/test/kotlin/me/youngjun/daangnmarket/api/sign/controller/SignApiControllerTest.kt
+++ b/src/test/kotlin/me/youngjun/daangnmarket/api/sign/controller/SignApiControllerTest.kt
@@ -26,7 +26,7 @@ internal class SignApiControllerTest : DescribeSpec({
         val resultAction = mockMvc.perform(
             MockMvcRequestBuilders.post("/api/v1/login")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(loginDtoJson)
+                .content(loginDtoJson),
         )
 
         context("ID/PW가 일치하면") {
@@ -45,7 +45,7 @@ internal class SignApiControllerTest : DescribeSpec({
                 resultAction
                     .andExpect(
                         MockMvcResultMatchers
-                            .content().contentType(MediaType.APPLICATION_JSON)
+                            .content().contentType(MediaType.APPLICATION_JSON),
                     )
             }
         }
@@ -57,10 +57,11 @@ internal class SignApiControllerTest : DescribeSpec({
         private val loginDto = LoginRequestDto("youngjun108059@gmail.com", "1234")
         val loginDtoJson = objectMapper.writeValueAsString(loginDto)!!
         val loginResponseDto = LoginResponseDto(
+            id = 1,
             name = "YoungJun",
             grantType = "Bearer",
             accessToken = "test123token",
-            accessTokenExpiresIn = 1673557504848
+            accessTokenExpiresIn = 1673557504848,
         )
     }
 }

--- a/vue/src/views/product/MyProductListView.vue
+++ b/vue/src/views/product/MyProductListView.vue
@@ -63,7 +63,6 @@ import $axiosInst from "@/common/AxiosInst"
 import router from "@/router";
 import chatImg from "@/assets/img/chat.png";
 import heartImg from "@/assets/img/heart.png";
-import addButton from "@/assets/img/add-button.png";
 import reservedImg from "@/assets/img/reserved.png";
 import completedImg from "@/assets/img/completed.png";
 import $store from "@/store/store";
@@ -87,11 +86,8 @@ export default {
       ],
       chatImg: chatImg,
       heartImg: heartImg,
-      addButton: addButton,
       reservedImg: reservedImg,
       completedImg: completedImg,
-      userName: "",
-      categoryName: "",
       tab: null,
     });
     onMounted(() => {
@@ -208,7 +204,6 @@ export default {
 };
 </script>
 
-<!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
 .product-row {
   position: relative;


### PR DESCRIPTION
## ✨ Summary

나의 당근 → 판매내역 페이지를 구성합니다.

<img width="250" alt="image" src="https://user-images.githubusercontent.com/42997924/224557629-a3265f10-b4db-45b8-82c7-fbf58c59c3e8.gif">

## ✍🏻 Describe changes

- 상품 상태 변경 API 추가 개발
- 판매중 / 거래완료 탭 구성
- 상품 판매 상태 변경 버튼 및 CTA 구현
- (Landing) 상품 상세 정보 보기 페이지

## 📌 Issue number

resolved: #45 