### PR TITLE
[FE] 상품 상세 페이지 - 같은 판매자 상품 보기 기능 [ISSUE-65]

### DIFF
--- a/src/main/kotlin/me/youngjun/daangnmarket/api/member/controller/MemberApiController.kt
+++ b/src/main/kotlin/me/youngjun/daangnmarket/api/member/controller/MemberApiController.kt
@@ -24,9 +24,14 @@ class MemberApiController(
 
     @GetMapping("/api/v1/member")
     fun getMember(
+        @RequestParam("member_id") memberId: Long?,
         principal: Principal,
     ): ResponseEntity<MemberInfoResponseDto> {
-        val memberInfo = memberService.getMemberInfo(principal.name.toLong())
+        val memberInfo = if (memberId != null) {
+            memberService.getMemberInfo(memberId)
+        } else {
+            memberService.getMemberInfo(principal.name.toLong())
+        }
         return ResponseEntity(memberInfo, HttpStatus.OK)
     }
 

--- a/vue/src/App.vue
+++ b/vue/src/App.vue
@@ -26,8 +26,8 @@ body {
 
 .my-footer {
   background-color: lightgray;
-  position: absolute;
-  bottom: 12px;
+  position: fixed;
+  bottom: 0;
   right: 20px;
   width: 100%;
   padding: 20px 30px 20px 30px;

--- a/vue/src/router/index.js
+++ b/vue/src/router/index.js
@@ -11,6 +11,7 @@ import MyPageView from "@/views/member/MyPageView.vue";
 import CategoryView from "@/views/product/CategoryView.vue";
 import LikesProductListView from "@/views/product/LikesProductListView.vue";
 import MyProductListView from "@/views/product/MyProductListView.vue";
+import UserProductListView from "@/views/product/UserProductListView.vue";
 
 const router = createRouter({
     history: createWebHistory(),
@@ -69,6 +70,11 @@ const router = createRouter({
             path: "/my-products",
             name: "MyProductListView",
             component: MyProductListView,
+        },
+        {
+            path: "/member-products/:memberId",
+            name: "UserProductListView",
+            component: UserProductListView,
         },
     ],
 });

--- a/vue/src/views/member/JoinView.vue
+++ b/vue/src/views/member/JoinView.vue
@@ -86,7 +86,7 @@ export default {
       getAreaList();
     });
     const getAreaList = () => {
-      const url = "http://localhost:8081/api/v1/area/list";
+      const url = "/api/v1/area/list";
       axios
           .get(url)
           .then(function (response) {
@@ -141,7 +141,7 @@ export default {
       if (this.validationCheck() === false) {
         return false;
       }
-      const url = "http://localhost:8081/api/v1/member";
+      const url = "/api/v1/member";
       const memberJoinForm = {
         email: this.email,
         password: this.password,

--- a/vue/src/views/product/ProductDetailView.vue
+++ b/vue/src/views/product/ProductDetailView.vue
@@ -7,18 +7,13 @@
     <!--TODO("내 게시글일 때 수정/삭제 가능 추가")-->
   </v-toolbar>
   <v-container fluid>
-    <div class="image-slider">
-      <v-carousel height="250px">
-        <v-carousel-item
-            v-for="(image, index) in state.productDetail.imageUrls"
-            :key="index"
-            eager
-            reverse-transition="fade-transition"
-            transition="fade-transition">
-          <v-img :src="image" height="100%" eager/>
-        </v-carousel-item>
-      </v-carousel>
-    </div>
+    <v-carousel height="250px">
+      <v-carousel-item
+          v-for="(image, index) in state.productDetail.imageUrls"
+          :key="index">
+        <v-img :src="image" height="100%"/>
+      </v-carousel-item>
+    </v-carousel>
     <v-row class="mt-2 mb-2 seller-info">
       <div style="float: left; width: 25%">
         <img :src="state.productDetail.sellerImageUrl" alt="판매자-프로필-사진" width="70" height="70"/>
@@ -51,13 +46,34 @@
       </div>
     </v-row>
   </v-container>
-  <!--TODO("판매상품 추가 + 모두보기 landing")-->
-  <v-row class="same-seller-info">
+  <v-row v-if="state.sellersProducts.length !== 1" class="same-seller-info">
     <div style="float: left;">
-      {{ state.productDetail.nickname }}님의 판매상품
+      <span style="color: #ff931e">{{ state.productDetail.nickname }}</span>님의 판매상품
     </div>
-    <v-icon icon="mdi-arrow-right" style="margin-right: 30px; float: right;"></v-icon>
+    <v-icon
+        icon="mdi-arrow-right"
+        style="margin-right: 30px; float: right;"
+        @click="goUserProductListView()"
+    ></v-icon>
   </v-row>
+  <v-container v-if="state.sellersProducts.length !== 1" class="mb-16">
+    <v-row
+        class="same-seller-products"
+        v-for="product in state.sellersProducts"
+        :key="product.id"
+        @click="goDetailPage(product.id)"
+        style="float: left; width: 55%; margin-top: 10px;"
+    >
+      <v-col v-if="productId !== product.id.toString()">
+        <div>
+          <img :src="product.imgUrl" alt="이미지" width="125" height="100"/>
+        </div>
+        <div class="more-products">{{ product.title }}</div>
+        <div class="more-products">{{ product.areaName }} • {{ $time.elapsedTime(product.createdDateTime) }}</div>
+        <div class="more-products">{{ $money.currency(product.price) }} 원</div>
+      </v-col>
+    </v-row>
+  </v-container>
   <v-row class="my-footer">
     <div class="like-button" v-if="state.productDetail.isLikes === true">
       <v-img
@@ -95,6 +111,7 @@ import $axiosInst from "@/common/AxiosInst"
 import reservedImg from "@/assets/img/reserved.png";
 import completedImg from "@/assets/img/completed.png";
 import {useRoute} from "vue-router";
+import router from "@/router";
 
 export default {
   setup() {
@@ -108,6 +125,7 @@ export default {
             price: 0,
             likesCount: 0,
             chatCount: 0,
+            memberId: 0,
             status: "",
             createdDateTime: "",
             imageUrls: [],
@@ -120,19 +138,45 @@ export default {
           },
       reservedImg: reservedImg,
       completedImg: completedImg,
-      userName: ""
+      sellersProducts: [
+        {
+          id: 0,
+          areaName: "",
+          title: "",
+          price: 0,
+          imgUrl: "",
+        },
+      ],
     });
-    onMounted(() => {
-      getProduct();
+    onMounted(async () => {
+      await getProduct();
+      await getSellerProducts();
     });
-    const getProduct = () => {
+    const getProduct = async () => {
       const url = "/api/v1/product";
       const params = {product_id: productId}
-      $axiosInst
+      await $axiosInst
           .get(url, {params})
           .then(function (response) {
             console.log(response);
             state.productDetail = response.data;
+          })
+          .catch(function (error) {
+            console.log(error);
+            alert("서버 에러입니다. \n잠시 후 다시 시도해주세요.");
+          });
+    };
+    const getSellerProducts = async () => {
+      const url = "/api/v1/product/list";
+      const params = {
+        member_id: state.productDetail.memberId,
+        status: "TRADING",
+      }
+      await $axiosInst
+          .get(url, {params})
+          .then(function (response) {
+            console.log(response);
+            state.sellersProducts = response.data.content;
           })
           .catch(function (error) {
             console.log(error);
@@ -152,9 +196,15 @@ export default {
             alert("서버 에러입니다. \n잠시 후 다시 시도해주세요.");
           });
     };
+    const goDetailPage = (id) => {
+      router.push({
+        name: "ProductDetailView",
+        params: {productId: id}
+      })
+    };
     const cancelLikesApi = () => {
-      const url = "api/v1/likes"
-      const params = {product_id: productId}
+      const url = "api/v1/likes";
+      const params = {product_id: productId};
       $axiosInst
           .delete(url, {params})
           .then(function () {
@@ -165,11 +215,21 @@ export default {
             alert("서버 에러입니다. \n잠시 후 다시 시도해주세요.");
           });
     };
+    const goUserProductListView = () => {
+      router.push({
+        name: "UserProductListView",
+        params: {
+          memberId: state.productDetail.memberId
+        }
+      })
+    };
     return {
       productId,
       state,
       likesApi,
       cancelLikesApi,
+      goDetailPage,
+      goUserProductListView,
     };
   }
 };
@@ -193,6 +253,12 @@ export default {
   padding-right: 15px;
 }
 
+.more-products {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .location {
   font-size: 14px;
   color: gray;
@@ -206,6 +272,7 @@ export default {
 }
 
 .product-title {
+  margin-left: 5px;
   font-size: 20px;
   float: left;
 }
@@ -224,6 +291,12 @@ export default {
   display: inline;
   margin-left: 15px;
   margin-top: 20px;
+}
+
+.same-seller-products {
+  display: inline;
+  margin-top: 10px;
+  font-size: 12px;
 }
 
 .state-img {

--- a/vue/src/views/product/ProductListView.vue
+++ b/vue/src/views/product/ProductListView.vue
@@ -152,7 +152,6 @@ export default {
 };
 </script>
 
-<!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
 .product-row {
   position: relative;
@@ -169,7 +168,6 @@ export default {
 }
 
 .homeButton {
-  /*border-right: solid 3px #2c3e50;*/
   margin-left: 1px;
 }
 

--- a/vue/src/views/product/UserProductListView.vue
+++ b/vue/src/views/product/UserProductListView.vue
@@ -1,0 +1,5 @@
+<template>
+  <v-toolbar color="orange" elevation="2">
+    <v-icon icon="mdi-arrow-left" class="toolbar-icon"></v-icon>
+  </v-toolbar>
+</template>


### PR DESCRIPTION
## ✨ Summary

상품 상세 페이지 하단에 같은 판매자 상품 보기 기능을 개발했습니다.

<img width="250" alt="image" src="https://user-images.githubusercontent.com/42997924/225051207-db9932ce-4ede-4aca-8d3c-e85115f95cb5.gif">

## ✍🏻 Describe changes

- 같은 판매자 상품 조회 API 호출
- 판매자 상품 더보기 이동 버튼 연결(CTA)
- 판매 상품이 2개 이상일 경우만 노출
- 현재 조회된 상품은 "같은 판매자 상품 보기"에서 제외

## 📌 Issue number

resolved: #65 